### PR TITLE
대시보드 데이터 연동

### DIFF
--- a/app/api/family/care-logs/route.ts
+++ b/app/api/family/care-logs/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const limit = Number(searchParams.get("limit")) || 3;
+
+  // TODO: 실제 API 연동
+  const mockData = {
+    careLogs: [
+      {
+        id: "1",
+        date: "2024-03-20",
+        caregiverName: "이요양",
+        activities: ["식사도움", "목욕도움", "말벗·격려 및 위로"],
+      },
+      {
+        id: "2",
+        date: "2024-03-19",
+        caregiverName: "이요양",
+        activities: ["식사도움", "청소 및 주변정돈", "외출 시 동행"],
+      },
+      {
+        id: "3",
+        date: "2024-03-18",
+        caregiverName: "이요양",
+        activities: ["식사도움", "배변도움", "운동보조"],
+      },
+    ].slice(0, limit),
+  };
+
+  return NextResponse.json(mockData);
+} 

--- a/app/api/family/patients/summary/route.ts
+++ b/app/api/family/patients/summary/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  // TODO: 실제 API 연동
+  const mockData = {
+    familyName: "김가족",
+    patientName: "김환자",
+    caregiverName: "이요양",
+    caregiverStatus: "working" as const,
+  };
+
+  return NextResponse.json(mockData);
+} 

--- a/app/family/dashboard/page.tsx
+++ b/app/family/dashboard/page.tsx
@@ -1,15 +1,86 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { FamilyDashboard } from "@/components/dashboard/family-dashboard";
 
+interface PatientSummary {
+  familyName: string;
+  patientName: string;
+  caregiverName: string;
+  caregiverStatus: "working" | "scheduled" | "off";
+}
+
+interface CareLog {
+  id: string;
+  date: string;
+  caregiverName: string;
+  activities: string[];
+}
+
 export default function FamilyDashboardPage() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<PatientSummary | null>(null);
+  const [careLogs, setCareLogs] = useState<CareLog[]>([]);
+
+  useEffect(() => {
+    async function fetchDashboardData() {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // 환자 요약 정보 조회
+        const summaryResponse = await fetch("/api/family/patients/summary");
+        if (!summaryResponse.ok) {
+          throw new Error("환자 정보를 불러오는데 실패했습니다.");
+        }
+        const summaryData = await summaryResponse.json();
+
+        // 최근 돌봄 일지 조회
+        const careLogsResponse = await fetch("/api/family/care-logs?limit=3");
+        if (!careLogsResponse.ok) {
+          throw new Error("돌봄 일지를 불러오는데 실패했습니다.");
+        }
+        const careLogsData = await careLogsResponse.json();
+
+        setSummary(summaryData);
+        setCareLogs(careLogsData.careLogs);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "데이터를 불러오는데 실패했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchDashboardData();
+  }, []);
+
+  const handleCareLogClick = (logId: string) => {
+    router.push(`/family/care-logs/${logId}`);
+  };
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  if (!summary) {
+    return <div>데이터를 찾을 수 없습니다.</div>;
+  }
+
   return (
     <FamilyDashboard
-      familyName={""}
-      patientName={""}
-      caregiverName={""}
-      caregiverStatus={"working"}
-      careLogs={[]}
+      familyName={summary.familyName}
+      patientName={summary.patientName}
+      caregiverName={summary.caregiverName}
+      caregiverStatus={summary.caregiverStatus}
+      careLogs={careLogs}
+      onCareLogClick={handleCareLogClick}
     />
   );
 }

--- a/components/dashboard/family-dashboard.tsx
+++ b/components/dashboard/family-dashboard.tsx
@@ -22,6 +22,7 @@ interface FamilyDashboardProps {
   caregiverName: string;
   caregiverStatus: "working" | "scheduled" | "off";
   careLogs: CareLog[];
+  onCareLogClick?: (logId: string) => void;
 }
 
 export function FamilyDashboard({
@@ -43,6 +44,7 @@ export function FamilyDashboard({
       activities: ["식사도움", "청소 및 주변정돈", "외출 시 동행"],
     },
   ],
+  onCareLogClick,
 }: FamilyDashboardProps) {
   const [date, setDate] = React.useState<Date | undefined>(new Date());
 
@@ -111,7 +113,12 @@ export function FamilyDashboard({
                   <div key={log.id} className="p-4 border rounded-lg">
                     <div className="flex justify-between items-center mb-2">
                       <h3 className="text-lg font-medium">{log.date}</h3>
-                      <Button variant="outline" size="sm" className="h-8">
+                      <Button 
+                        variant="outline" 
+                        size="sm" 
+                        className="h-8"
+                        onClick={() => onCareLogClick?.(log.id)}
+                      >
                         <ClipboardList className="w-4 h-4 mr-1" />
                         상세보기
                       </Button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #95  #117 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. GET /family/patients/summary - 환자 요약 정보 API
2. GET /family/care-logs?limit=3 - 최근 돌봄 일지 API
3. 데이터 로딩 상태 표시
4. 에러 메시지 표시
5. 카드 클릭 시 일지 상세 페이지로 라우팅
6. FamilyDashboard 컴포넌트에 onCareLogClick prop을 추가하고 클릭 이벤트를 연결



