### PR TITLE
돌봄 일지 리스트 API 연동

### DIFF
--- a/app/family/care-logs/page.tsx
+++ b/app/family/care-logs/page.tsx
@@ -1,5 +1,111 @@
-import { FamilyCareLogList } from "@/components/care-logs/family-care-log-list";
+"use client";
 
-export default function FamilyCareLogsPage() {
-  return <FamilyCareLogList patientName="이환자" />;
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface CareLog {
+  id: string;
+  date: string;
+  caregiverName: string;
+  activities: string[];
+  status: string;
+}
+
+export default function CareLogsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [logs, setLogs] = useState<CareLog[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [page, setPage] = useState(1);
+
+  const date = searchParams.get("date") || "";
+  const status = searchParams.get("status") || "";
+
+  const fetchLogs = async () => {
+    try {
+      setIsLoading(true);
+      const queryParams = new URLSearchParams({
+        date,
+        status,
+        page: page.toString(),
+      });
+
+      const response = await fetch(`/family/care-logs?${queryParams.toString()}`);
+      if (!response.ok) {
+        throw new Error("돌봄 일지를 불러오는데 실패했습니다.");
+      }
+
+      const data = await response.json();
+      if (data.logs.length === 0) {
+        setHasMore(false);
+        return;
+      }
+
+      setLogs(prev => [...prev, ...data.logs]);
+      setPage(prev => prev + 1);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 필터 변경 시 데이터 리셋
+  useEffect(() => {
+    setLogs([]);
+    setPage(1);
+    setHasMore(true);
+    fetchLogs();
+  }, [date, status]);
+
+  // 무한 스크롤
+  const handleScroll = () => {
+    if (
+      window.innerHeight + document.documentElement.scrollTop
+      === document.documentElement.offsetHeight
+    ) {
+      if (hasMore && !isLoading) {
+        fetchLogs();
+      }
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [hasMore, isLoading]);
+
+  const handleLogClick = (logId: string) => {
+    router.push(`/family/care-logs/${logId}`);
+  };
+
+  return (
+    <div className="p-4">
+      <div className="space-y-4">
+        {logs.map((log) => (
+          <div
+            key={log.id}
+            onClick={() => handleLogClick(log.id)}
+            className="p-4 border rounded-lg cursor-pointer hover:bg-gray-50"
+          >
+            <div className="flex justify-between items-center">
+              <div>
+                <h3 className="font-medium">{log.caregiverName}</h3>
+                <p className="text-sm text-gray-500">{log.date}</p>
+              </div>
+              <div className="text-sm text-gray-500">{log.status}</div>
+            </div>
+            <div className="mt-2 text-sm text-gray-600">
+              {log.activities.join(", ")}
+            </div>
+          </div>
+        ))}
+      </div>
+      
+      {isLoading && (
+        <div className="text-center py-4">로딩 중...</div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #96 

## 📝작업 내용

1. API 연동
-GET /family/care-logs?date=&status= 엔드포인트 사용
-페이지네이션을 위한 page 파라미터 추가
2. 무한 스크롤
-스크롤이 페이지 하단에 도달하면 추가 데이터 로드
-로딩 상태와 더 보기 여부 관리
3. URL 쿼리 파라미터 동기화
-useSearchParams로 URL의 date와 status 파라미터 관리
-파라미터 변경 시 데이터 리셋 및 재로드
4. 상세 페이지 라우팅
-돌봄 일지 클릭 시 /family/care-logs/{id}로 이동



